### PR TITLE
Change Environment variables for HLS and DASH

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,8 +20,8 @@ You can set the following environment variables.
 | OME\_RTMP\_PROV\_PORT | 1935 |
 | OME\_SRT\_PROV\_PORT | 9999/udp |
 | OME\_MPEGTS\_PROV\_PORT | 4000-4005/udp |
-| OME\_HLS\_PUB\_PORT | 8080 |
-| OME\_DASH\_PUB\_PORT | 8080 |
+| OME\_HLS\_STREAM\_PORT | 8080 |
+| OME\_DASH\_STREAM\_PORT | 8080 |
 | OME\_TCP\_RELAY\_ADDRESS | \*:3478 |
 | OME\_ICE\_CANDIDATES | \*:10006-10010/udp |
 | OME\_SIGNALLING\_PORT | 3333 |


### PR DESCRIPTION
If we look at the default Server.xml config, you'll see the following settings:

`			<HLS>
				<Port>${env:OME_HLS_STREAM_PORT:8080}</Port>
				<WorkerCount>1</WorkerCount>
				<!-- If you want to use TLS, specify the TLS port -->
				<!-- <TLSPort>443</TLSPort> -->
			</HLS>
			<DASH>
				<Port>${env:OME_DASH_STREAM_PORT:8080}</Port>
				<WorkerCount>1</WorkerCount>
				<!-- If you want to use TLS, specify the TLS port -->
				<!-- <TLSPort>443</TLSPort> -->
			</DASH>
`

Back on the docs, it still says OME_DASH_PUB_PORT and OME_HLS_PUB_PORT. I found out after my ports didn't change while setting the env var in Docker.